### PR TITLE
Catch failed designs and prevent dcp generation

### DIFF
--- a/src/core_fuzzer.tcl
+++ b/src/core_fuzzer.tcl
@@ -99,9 +99,14 @@ proc synth {name ip} {
         close_project
         open_checkpoint "../data/$ip/$name.dcp"
         opt_design
-        catch { place_design }
-        catch { route_design }
-        write_checkpoint "../data/$ip/$name.dcp" -force
+        if {[catch { place_design; route_design }] == 0} {
+            write_checkpoint "../data/$ip/$name.dcp" -force
+        }
+        else {
+            #placeholder until we have a an error file descriptor setup.
+            set err [open "../data/$ip/$name.err" w]
+            close $err
+        }
     }
     close_project
 }


### PR DESCRIPTION
Temporary solution until file handler is implemented as mentioned in #15 