### PR TITLE
Split json and dcp files into their own directories

### DIFF
--- a/src/core.tcl
+++ b/src/core.tcl
@@ -17,7 +17,7 @@
 # This script opens a checkpoint file, and exports all of the design's properties into a JSON that can be parsed and imported into iGraph.
     # There is also an option to keep hierarchy (record_core), or flatten all of the hierarchy (record_flat_core)
 
-# This function is used in create_data.py that will export the IP core design into a JSON file to be imported into iGraph
+# This function is used in create_lib.py that will export the IP core design into a JSON file to be imported into iGraph
 # Should take an open output file, and expects a checkpoint to be open.
 proc record_core {out} {
     set i 0

--- a/src/core_fuzzer.tcl
+++ b/src/core_fuzzer.tcl
@@ -56,7 +56,7 @@ proc get_prop_dict { ip} {
 
     file delete -force "../data/$ip/out.txt"
     file delete -force "../data/$ip/props.txt"
-    set f [open "../data/$ip/properties.json" w]
+    set f [open "../data/$ip/json/properties.json" w]
     puts $f "\{\"PROPERTY\": \["
     set i 0
     dict for {property values} $accum {
@@ -95,13 +95,13 @@ proc get_prop_dict { ip} {
 proc synth {name ip} {
     set C [get_ips]
 	set f [synth_ip $C]
-    if {[catch {file rename -force $f "../data/$ip/$name.dcp"}] == 0} {
+    if {[catch {file rename -force $f "../data/$ip/dcp/$name.dcp"}] == 0} {
         close_project
-        open_checkpoint "../data/$ip/$name.dcp"
+        open_checkpoint "../data/$ip/dcp/$name.dcp"
         opt_design
         catch { place_design }
         catch { route_design }
-        write_checkpoint "../data/$ip/$name.dcp" -force
+        write_checkpoint "../data/$ip/dcp/$name.dcp" -force
     }
     close_project
 }

--- a/src/create_data.py
+++ b/src/create_data.py
@@ -53,6 +53,8 @@ class DataGenerator:
         random.seed(datetime.now().timestamp())
 
         self.data_dir = DATA_DIR / self.ip
+        self.data_json_path = self.data_dir / "json"
+        self.data_dcp_path = self.data_dir / "dcp"
         self.lib_dir = LIB_DIR / self.ip
         self.make_dirs()
         self.get_ip_props()
@@ -60,13 +62,14 @@ class DataGenerator:
 
     # Steps up the Folder Structure
     def make_dirs(self):
-        self.lib_dir.mkdir(parents=True, exist_ok=True)
-        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.data_dcp_path.mkdir(parents=True, exist_ok=True)
+        self.data_json_path.mkdir(parents=True, exist_ok=True)
+
 
     # Executes the TCL script that creates the dictionary of parameters of the IP (in a JSON)
     def get_ip_props(self):
         """Get Properties for configurable IP"""
-        if not (ROOT_PATH / "data" / self.ip / "properties.json").exists():
+        if not (self.data_json_path / "properties.json").exists():
             print("Running first time IP Property Dictionary Generation")
             process = self.launch("0")
             process.stdin.write(f"set ip {self.ip}\n")
@@ -76,7 +79,7 @@ class DataGenerator:
             process.stdin.write("exit\n")
             process.stdin.close()
             process.wait()
-        with open(ROOT_PATH / "data" / self.ip / "properties.json") as f:
+        with open(self.data_json_path / "properties.json") as f:
             self.ip_dict = json.load(f)
 
     def randomize_props(self, stream):
@@ -111,7 +114,7 @@ class DataGenerator:
             self.init_design(process.stdin)
             props = self.randomize_props(process.stdin)
             self.gen_design(i, process.stdin)
-            with open(self.data_dir / f"{i}_props.json", "w") as f:
+            with open(self.data_json_path / f"{i}_props.json", "w") as f:
                 json.dump(props, f, indent=4)
 
         for process in processes:

--- a/src/create_lib.py
+++ b/src/create_lib.py
@@ -273,7 +273,7 @@ class LibraryGenerator:
                     x = cell.name
                     y = y.name
                     templates[x][y] = {}
-                    templates[x][y]["file"] = str(self.templ_dir / x / y)
+                    templates[x][y]["file"] = f"library/{self.ip}/templates/{x}/{y}"
                     g_template = Graph.Read_Pickle(templates[x][y]["file"])
                     for template in g_template.vs.select(IS_PRIMITIVE=False, id_ne=0):
                         if template["ref"] not in used_list:

--- a/src/search_lib.py
+++ b/src/search_lib.py
@@ -21,13 +21,11 @@ import os
 import argparse
 import pickle
 import igraph
-import time
 import logging
-import sys
 from igraph import *
 from compare_v import *
 from multiprocessing import Pool
-from config import LIB_DIR, ROOT_PATH
+from config import DATA_DIR, ROOT_PATH
 
 # This script takes in a design (.dcp file) and an IP core name and searches for the IP core within the design
 
@@ -646,7 +644,7 @@ def find(ip, filename):
         import_dcp(filename)
         filename = filename.replace(".dcp", ".json")
 
-    fj = open(LIB_DIR / ip / "templates.json")
+    fj = open(DATA_DIR / ip / "json" / "templates.json")
     tmp = json.load(fj)
     templates = tmp["templates"]
     used_list = tmp["used"]


### PR DESCRIPTION
- fixed typo in core.tcl
- changed paths to reflect new dir hierarchy in core_fuzzer.tcl
- updated to put json in data/json and dcp in data/dcp in create_data and create_lib
- removed unused imports and updated path to reflect new dir hierarchy in search_lib
